### PR TITLE
Fixed undetermined wavelength range issue raised when creating labels.

### DIFF
--- a/HST/product_labels/wavelength_ranges.py
+++ b/HST/product_labels/wavelength_ranges.py
@@ -186,6 +186,10 @@ def ranges_from_one_filter(filter_name):
     # Check the list of exceptions first
     if filter_name in FILTER_EXCEPTIONS:
         return FILTER_EXCEPTIONS[filter_name]
+    # If there is no exact match in the exceptions, check for prefix
+    for filter in FILTER_EXCEPTIONS:
+        if filter_name.startswith(filter):
+            return FILTER_EXCEPTIONS[filter]
 
     # Otherwise, derive the wavelength ranges from the center wavelength
     # embedded within the filter name.


### PR DESCRIPTION
- Fixed #70 
-  Update the intelligence of `ranges_from_one_filter`. It will check the list of exceptions `FILTER_EXCEPTIONS` first, if there is no exact match in the exceptions, check for prefix. Previous we only check for the exact match in `FILTER_EXCEPTIONS`.
- Test run on `10770`, labels and bundles passed the validation
